### PR TITLE
Fix watcher function with minutes argument instead of minute

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -74,24 +74,22 @@ func Parse() {
 // StartMonitoring starts watcher that monitors items
 func StartMonitoring() {
 	conf = configuration.ParseConfig()
-	if conf.RunIntervalMin > 0 {
-
-		runParser()
-
-		gocron.Every(uint64(conf.RunIntervalMin)).Minute().Do(runParser)
-		<-gocron.Start()
-
-		c := make(chan os.Signal, 2)
-		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			<-c
-			gocron.Clear()
-			os.Exit(1)
-		}()
-
-	} else {
+	if conf.RunIntervalMin <= 0 {
 		fmt.Println("Please provide valid watcher run interval (larger than 0)")
+		return
 	}
+
+	runParser()
+	gocron.Every(uint64(conf.RunIntervalMin)).Minutes().Do(runParser)
+	<-gocron.Start()
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		gocron.Clear()
+		os.Exit(1)
+	}()
 }
 
 func runParser() {


### PR DESCRIPTION
## Problem
Running serve cmd threw an error because misusage of the cron job minute function

## Solution
Replaced previous function with the correct one and lowered the complexity of the function by removing else in selection.

## Testing
Simply running ./njuhalo s should work now
